### PR TITLE
Disable auto deployment and update docs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages
+name: CI
 
 on:
   push:
@@ -16,12 +16,3 @@ jobs:
         run: npm install
       - name: Lint code
         run: npm run lint
-      - name: Configure git user
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-      - name: Deploy to GitHub Pages
-        run: npm run deploy
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ npm run build
 npm run deploy
 ```
 
-### Automatic deployment
+### Continuous integration
 
-A GitHub Actions workflow defined at `.github/workflows/deploy.yml` builds and deploys the site whenever changes are pushed to the `main` branch.
+A GitHub Actions workflow defined at `.github/workflows/deploy.yml` installs dependencies and runs `npm run lint` whenever changes are pushed to the `main` branch. Automatic deployment to GitHub Pages has been disabled.
 
 
 ## Expanding the ESLint configuration


### PR DESCRIPTION
## Summary
- stop deploying to GitHub Pages in the workflow
- update README to document the new CI behavior

## Testing
- `npm run lint` *(fails: cannot find package `@eslint/js`)*
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails due to environment restrictions)*


------
https://chatgpt.com/codex/tasks/task_e_6847519d4bb4832c91452949483d5633